### PR TITLE
Dismiss dependabot alert about react-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@types/react-dom": "^18.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
     "typescript": "^4.7.4",
     "web-vitals": "^2.1.4"
   },
@@ -74,6 +73,7 @@
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest-junit": "^14.0.0",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "react-scripts": "5.0.1"
   }
 }


### PR DESCRIPTION
The alert complains about a dependency from the react scripts, but these are not production dependencies, so just moving it to devDependencies